### PR TITLE
Add NOTAM asking to send TOBT to CDM URL

### DIFF
--- a/vATIS Profile - LFFF.json
+++ b/vATIS Profile - LFFF.json
@@ -166,7 +166,7 @@
         },
         {
           "ordinal": 2,
-          "text": "SEND YOUR TOBT TO CDM.VATSIM.FR.",
+          "text": "SEND YOUR TOBT AT CDM.VATSIM.FR.",
           "enabled": false
         }
       ],
@@ -511,7 +511,7 @@
         },
         {
           "ordinal": 2,
-          "text": "SEND YOUR TOBT TO CDM.VATSIM.FR.",
+          "text": "SEND YOUR TOBT AT CDM.VATSIM.FR.",
           "enabled": false
         }
       ],

--- a/vATIS Profile - LFFF.json
+++ b/vATIS Profile - LFFF.json
@@ -147,6 +147,14 @@
         {
           "string": "RWYS 27L AND 26R",
           "spoken": "RWYS TWO SEVEN LEFT AND TWO SIX RIGHT"
+        },
+        {
+          "string": "TOBT",
+          "spoken": "TEE-O-BEE-TEE"
+        },
+        {
+          "string": "CDM.VATSIM.FR",
+          "spoken": "CDM DOT VATSIM DOT FR"
         }
       ],
       "airportConditionDefinitions": [],
@@ -154,6 +162,11 @@
         {
           "ordinal": 1,
           "text": "CDM IN USE.",
+          "enabled": false
+        },
+        {
+          "ordinal": 2,
+          "text": "SEND YOUR TOBT TO CDM.VATSIM.FR.",
           "enabled": false
         }
       ],
@@ -479,6 +492,14 @@
         {
           "string": "7Y",
           "spoken": "SEVEN YANKEE"
+        },
+        {
+          "string": "TOBT",
+          "spoken": "TEE-O-BEE-TEE"
+        },
+        {
+          "string": "CDM.VATSIM.FR",
+          "spoken": "CDM DOT VATSIM DOT FR"
         }
       ],
       "airportConditionDefinitions": [],
@@ -486,6 +507,11 @@
         {
           "ordinal": 1,
           "text": "CDM IN USE.",
+          "enabled": false
+        },
+        {
+          "ordinal": 2,
+          "text": "SEND YOUR TOBT TO CDM.VATSIM.FR.",
           "enabled": false
         }
       ],

--- a/vATIS Profile - LFMM.json
+++ b/vATIS Profile - LFMM.json
@@ -641,6 +641,14 @@
         {
           "string": "6S",
           "spoken": "SIX SIERRA"
+        },
+        {
+          "string": "TOBT",
+          "spoken": "TEE-O-BEE-TEE"
+        },
+        {
+          "string": "CDM.VATSIM.FR",
+          "spoken": "CDM DOT VATSIM DOT FR"
         }
       ],
       "airportConditionDefinitions": [],
@@ -648,6 +656,11 @@
         {
           "ordinal": 1,
           "text": "CDM IN USE.",
+          "enabled": false
+        },
+        {
+          "ordinal": 2,
+          "text": "SEND YOUR TOBT TO CDM.VATSIM.FR.",
           "enabled": false
         }
       ],

--- a/vATIS Profile - LFMM.json
+++ b/vATIS Profile - LFMM.json
@@ -660,7 +660,7 @@
         },
         {
           "ordinal": 2,
-          "text": "SEND YOUR TOBT TO CDM.VATSIM.FR.",
+          "text": "SEND YOUR TOBT AT CDM.VATSIM.FR.",
           "enabled": false
         }
       ],


### PR DESCRIPTION
As many pilots don't read the controllers' info lines, they may not understand the action required with 'CDM IN USE'. This add a 2nd NOTAM with text 'SEND YOUR TOBT TO CDM.VATSIM.FR' and its related contractions.