### PR TITLE
AIRAC 2411 Update

### DIFF
--- a/vATIS Profile - LFBB.json
+++ b/vATIS Profile - LFBB.json
@@ -1488,7 +1488,7 @@
         {
           "id": "c8c2265e-835e-4de3-b8e1-a32a053b1ffa",
           "name": "LFBH 09",
-          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 5E",
+          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 6E",
           "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -1497,7 +1497,7 @@
         {
           "id": "8819d90d-9773-4b9e-9266-93dce0472fbc",
           "name": "LFBH 27",
-          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. SID 5W",
+          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. SID 6W",
           "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -1514,12 +1514,12 @@
           "spoken": "BON-JUR"
         },
         {
-          "string": "5E",
-          "spoken": "FIVE ECHO"
+          "string": "6E",
+          "spoken": "SIX ECHO"
         },
         {
-          "string": "5W",
-          "spoken": "FIVE WHISKEY"
+          "string": "6W",
+          "spoken": "SIX WHISKEY"
         }
       ],
       "airportConditionDefinitions": [],

--- a/vATIS Profile - LFFF.json
+++ b/vATIS Profile - LFFF.json
@@ -25,7 +25,7 @@
         {
           "id": "24f418d4-5ecd-499d-8817-49be2b84c216",
           "name": "LFPG 08/09 EL",
-          "airportConditions": "EXPECT 7E 7N ILS 09L AND 7E 7N ILS 08R. ARR RWYS 09L AND 08R, DEP RWYS 09R AND 08L. SID 5G AND 5H.",
+          "airportConditions": "EXPECT 7E 7N ILS 09L AND 7E 7N ILS 08R. ARR RWYS 09L AND 08R, DEP RWYS 09R AND 08L. SID 6G AND 6H.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -34,7 +34,7 @@
         {
           "id": "46433c45-4f02-4d74-bcbd-8e9219de1f1d",
           "name": "LFPG 26/27 WL",
-          "airportConditions": "EXPECT 7W ILS 27R AND 7W ILS 26L. ARR RWYS 27R AND 26L, DEP RWYS 27L AND 26R. SID 5A AND 5B.",
+          "airportConditions": "EXPECT 7W ILS 27R AND 7W ILS 26L. ARR RWYS 27R AND 26L, DEP RWYS 27L AND 26R. SID 6A AND 6B.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -43,7 +43,7 @@
         {
           "id": "41817aa5-6464-4449-954f-f50002405587",
           "name": "LFPG 08/09 EI",
-          "airportConditions": "EXPECT 7E 7N ILS 09L AND 7E 7N ILS 08R. ARR RWYS 09L AND 08R, DEP RWYS 09R AND 08L. SID 5K AND 5L.",
+          "airportConditions": "EXPECT 7E 7N ILS 09L AND 7E 7N ILS 08R. ARR RWYS 09L AND 08R, DEP RWYS 09R AND 08L. SID 6K AND 6L.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -52,7 +52,7 @@
         {
           "id": "892c3007-e9fd-4887-92cb-e99d1351b357",
           "name": "LFPG 26/27 WI",
-          "airportConditions": "EXPECT 7W ILS 27R AND 7W ILS 26L. ARR RWYS 27R AND 26L, DEP RWYS 27L AND 26R. SID 5D AND 5E.",
+          "airportConditions": "EXPECT 7W ILS 27R AND 7W ILS 26L. ARR RWYS 27R AND 26L, DEP RWYS 27L AND 26R. SID 6D AND 6E.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -73,36 +73,36 @@
           "spoken": "BON-JUR"
         },
         {
-          "string": "5G",
-          "spoken": "FIVE GOLF"
+          "string": "6G",
+          "spoken": "SIX GOLF"
         },
         {
-          "string": "5H",
-          "spoken": "FIVE HOTEL"
+          "string": "6H",
+          "spoken": "SIX HOTEL"
         },
         {
-          "string": "5A",
-          "spoken": "FIVE ALPHA"
+          "string": "6A",
+          "spoken": "SIX ALPHA"
         },
         {
-          "string": "5B",
-          "spoken": "FIVE BRAVO"
+          "string": "6B",
+          "spoken": "SIX BRAVO"
         },
         {
-          "string": "5K",
-          "spoken": "FIVE KILO"
+          "string": "6K",
+          "spoken": "SIX KILO"
         },
         {
-          "string": "5L",
-          "spoken": "FIVE LIMA"
+          "string": "6L",
+          "spoken": "SIX LIMA"
         },
         {
-          "string": "5D",
-          "spoken": "FIVE DELTA"
+          "string": "6D",
+          "spoken": "SIX DELTA"
         },
         {
-          "string": "5E",
-          "spoken": "FIVE ECHO"
+          "string": "6E",
+          "spoken": "SIX ECHO"
         },
         {
           "string": "7E",
@@ -407,7 +407,7 @@
         {
           "id": "0c6fa667-b19a-4def-a167-6d5a330ca8f8",
           "name": "LFPO 24/25 WL",
-          "airportConditions": "EXPECT 7W ILS 25. ARR RWY 25, DEP RWY 24. SID 1W.",
+          "airportConditions": "EXPECT 7W ILS 25. ARR RWY 25, DEP RWY 24. SID 2W.",
           "notams": "",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
@@ -417,7 +417,7 @@
         {
           "id": "59d33953-ceb1-4678-84f1-03a2a13a1bd9",
           "name": "LFPO 07/06 EL",
-          "airportConditions": "EXPECT 7E ILS 06. ARR RWY 06, DEP RWY 07. SID 1E.",
+          "airportConditions": "EXPECT 7E ILS 06. ARR RWY 06, DEP RWY 07. SID 2E.",
           "notams": "",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
@@ -427,7 +427,7 @@
         {
           "id": "bdb0ab47-6fa0-4803-b984-856bd66397e9",
           "name": "LFPO 24/25 WI",
-          "airportConditions": "EXPECT 7W ILS 25. ARR RWY 25, DEP RWY 24. SID 1Q.",
+          "airportConditions": "EXPECT 7W ILS 25. ARR RWY 25, DEP RWY 24. SID 2Q.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -436,7 +436,7 @@
         {
           "id": "7be05da3-3954-4f08-825c-80964fd0d9ba",
           "name": "LFPO 07/06 EI",
-          "airportConditions": "EXPECT 7E 7Y ILS 06. ARR RWY 06, DEP RWY 07. SID 1G.",
+          "airportConditions": "EXPECT 7E 7Y ILS 06. ARR RWY 06, DEP RWY 07. SID 2G.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -453,20 +453,20 @@
           "spoken": "DEPARTURES"
         },
         {
-          "string": "1W",
-          "spoken": "ONE WHISKEY"
+          "string": "2W",
+          "spoken": "TWO WHISKEY"
         },
         {
-          "string": "1E",
-          "spoken": "ONE ECHO"
+          "string": "2E",
+          "spoken": "TWO ECHO"
         },
         {
-          "string": "1Q",
-          "spoken": "ONE QUEBEC"
+          "string": "2Q",
+          "spoken": "TWO QUEBEC"
         },
         {
-          "string": "1G",
-          "spoken": "ONE GOLF"
+          "string": "2G",
+          "spoken": "TWO GOLF"
         },
         {
           "string": "7E",
@@ -739,7 +739,7 @@
         {
           "id": "985d0721-8049-4540-a5a7-2d8ca76009f8",
           "name": "LFPB 07/09",
-          "airportConditions": "EXPECT 7E ILS 07. ARR RWY 07, DEP RWY 09. SID 5J.",
+          "airportConditions": "EXPECT 7E ILS 07. ARR RWY 07, DEP RWY 09. SID 6J.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -748,7 +748,7 @@
         {
           "id": "cad0e3e9-105e-4f52-884a-ec99f021fe91",
           "name": "LFPB 27/25",
-          "airportConditions": "EXPECT 7W ILS 27. ARR RNY 27, DEP RWY 25. SID 5C.",
+          "airportConditions": "EXPECT 7W ILS 27. ARR RNY 27, DEP RWY 25. SID 6C.",
           "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -765,12 +765,12 @@
           "spoken": "DEPARTURES"
         },
         {
-          "string": "5Q",
-          "spoken": "FIVE QUEBEC"
+          "string": "6J",
+          "spoken": "SIX JULIET"
         },
         {
-          "string": "5C",
-          "spoken": "FIVE CHARLIE"
+          "string": "6C",
+          "spoken": "SIX CHARLIE"
         },
         {
           "string": "7E",

--- a/vATIS Profile - LFMM.json
+++ b/vATIS Profile - LFMM.json
@@ -25,7 +25,7 @@
         {
           "id": "d8769532-b9ff-415a-be36-813843d57777",
           "name": "LFMT 12",
-          "airportConditions": "EXPECT RNP RWY 12L. ARR RWY 12L, DEP RWY 12L. SID 6L",
+          "airportConditions": "EXPECT RNP RWY 12L. ARR RWY 12L, DEP RWY 12L. SID 7L",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -34,7 +34,7 @@
         {
           "id": "1a764042-3e6f-4bc8-873b-e5d614115faf",
           "name": "LFMT 30",
-          "airportConditions": "EXPECT ILS Z RWY 30R. ARR RWY 30R, DEP RWY 30R. SID 6R",
+          "airportConditions": "EXPECT ILS Z RWY 30R. ARR RWY 30R, DEP RWY 30R. SID 7R",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -51,12 +51,12 @@
           "spoken": "DEPARTURES"
         },
         {
-          "string": "6L",
-          "spoken": "SIX LIMA"
+          "string": "7L",
+          "spoken": "SEVEN LIMA"
         },
         {
-          "string": "6R",
-          "spoken": "SIX ROMEO"
+          "string": "7R",
+          "spoken": "SEVEN ROMEO"
         },
         {
           "string": "Z",
@@ -3828,7 +3828,7 @@
         {
           "id": "01b6c9d3-217a-42fb-901a-daa8b22955eb",
           "name": "LFLS 09",
-          "airportConditions": "EXPECT ILS RWY 09. ARR RWY 09, DEP RWY 09. SID 6E",
+          "airportConditions": "EXPECT ILS RWY 09. ARR RWY 09, DEP RWY 09. SID 8E",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -3837,7 +3837,7 @@
         {
           "id": "33abe9bd-ece5-4a63-819f-02f3d823e7a4",
           "name": "LFLS 27",
-          "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. SID 6W",
+          "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. SID 8W",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -3854,12 +3854,12 @@
           "spoken": "DEPARTURES"
         },
         {
-          "string": "6E",
-          "spoken": "SIX ECHO"
+          "string": "8E",
+          "spoken": "EIGHT ECHO"
         },
         {
           "string": "6W",
-          "spoken": "SIX WHISKEY"
+          "spoken": "EIGHT WHISKEY"
         }
       ],
       "airportConditionDefinitions": [],
@@ -4114,7 +4114,7 @@
         {
           "id": "02e47d8a-61a0-4a88-893e-95c0bace04bd",
           "name": "LFTW 18",
-          "airportConditions": "EXPECT RNP RWY 18. ARR RWY 18, DEP RWY 18. SID 3S",
+          "airportConditions": "EXPECT RNP RWY 18. ARR RWY 18, DEP RWY 18. SID 4S",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -4123,7 +4123,7 @@
         {
           "id": "06c471dd-75f1-4502-9270-c2a0766109f3",
           "name": "LFTW 36",
-          "airportConditions": "EXPECT RNP RWY 36. ARR RWY 36, DEP RWY 36. SID 3N",
+          "airportConditions": "EXPECT RNP RWY 36. ARR RWY 36, DEP RWY 36. SID 4N",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -4140,12 +4140,12 @@
           "spoken": "DEPARTURES"
         },
         {
-          "string": "3S",
-          "spoken": "THREE SIERRA"
+          "string": "4S",
+          "spoken": "FOUR SIERRA"
         },
         {
-          "string": "3N",
-          "spoken": "THREE NOVEMBER"
+          "string": "4N",
+          "spoken": "FOUR NOVEMBER"
         }
       ],
       "airportConditionDefinitions": [],


### PR DESCRIPTION
Updated the following airports for AIRAC **2411** compliance : 

LFPG / LFPB / LFPO / LFBH / LFMT / LFTW / LFLS

This is mostly SIDs validity indicator increments and the related contractions.