### PR TITLE
Remove '@' before contractions

### DIFF
--- a/vATIS Profile - LFBB.json
+++ b/vATIS Profile - LFBB.json
@@ -345,8 +345,8 @@
         {
           "id": "08674f88-f17f-450b-9d81-a884e711bc7b",
           "name": "LFBO 32",
-          "airportConditions": "EXPECT ILS RWY 32L. ARR RWY 32L, DEP RWY 32R. @SID @7B",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 32L. ARR RWY 32L, DEP RWY 32R. SID 7B",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -354,8 +354,8 @@
         {
           "id": "3562cbdd-d40e-4b82-b942-c757ba2f3855",
           "name": "LFBO 14",
-          "airportConditions": "EXPECT ILS RWY 14R. ARR RWY 14R, DEP RWY 14L. @SID @7A",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 14R. ARR RWY 14R, DEP RWY 14L. SID 7A",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -396,7 +396,7 @@
           "enabled": false
         },
         {
-          "text": "SEND YOUR @TOBT AT @CDMURL.",
+          "text": "SEND YOUR TOBT AT CDMURL.",
           "ordinal": 2,
           "enabled": false
         }
@@ -744,8 +744,8 @@
         {
           "id": "cd6daa1b-1ce0-403b-a64a-c0713c657584",
           "name": "LFBP 31",
-          "airportConditions": "EXPECT ILS RWY 31. ARR RWY 31, DEP RWY 31. @SID @2V",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 31. ARR RWY 31, DEP RWY 31. SID 2V",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -753,8 +753,8 @@
         {
           "id": "e72b93df-25b7-4565-a3a0-72d525c6229e",
           "name": "LFBP 13",
-          "airportConditions": "EXPECT VOR THEN VPT @A RWY 13. ARR RWY 13, DEP RWY 13. @SID @2D",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT VOR THEN VPT A RWY 13. ARR RWY 13, DEP RWY 13. SID 2D",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1132,8 +1132,8 @@
         {
           "id": "b047ad12-0ea7-4885-ab84-e2ff76dc3f50",
           "name": "LFBT 02",
-          "airportConditions": "EXPECT ILS @Z THEN VPT RWY 02. ARR RWY 02, DEP RWY 02. @SID @2M",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS Z THEN VPT RWY 02. ARR RWY 02, DEP RWY 02. SID 2M",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1141,8 +1141,8 @@
         {
           "id": "5ea0e31f-f735-402a-a4b9-999ba4df1822",
           "name": "LFBT 20",
-          "airportConditions": "EXPECT ILS RWY 20. ARR RWY 20, DEP RWY 20. @SID @2R",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 20. ARR RWY 20, DEP RWY 20. SID 2R",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1520,8 +1520,8 @@
         {
           "id": "65a6fa81-e78f-4d83-ba19-4b84b87b5643",
           "name": "LFBD 23",
-          "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. @SID @6P",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. SID 6P",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1529,8 +1529,8 @@
         {
           "id": "01af66f9-d860-421d-bbbd-bd1730a0e33c",
           "name": "LFBD 05",
-          "airportConditions": "EXPECT RNP RWY 05. ARR RWY 05, DEP RWY 05. @SID @6Q",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 05. ARR RWY 05, DEP RWY 05. SID 6Q",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1538,8 +1538,8 @@
         {
           "id": "00260a51-2930-4dac-b15f-52c2861516cf",
           "name": "LFBD 29",
-          "airportConditions": "EXPECT ILS RWY 29. ARR RWY 29, DEP RWY 29. @SID @6R",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 29. ARR RWY 29, DEP RWY 29. SID 6R",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1547,8 +1547,8 @@
         {
           "id": "23d444e1-b06a-4b10-b61a-567522158990",
           "name": "LFBD 11",
-          "airportConditions": "EXPECT RNP RWY 11. ARR RWY 11, DEP RWY 11. @SID @6E",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 11. ARR RWY 11, DEP RWY 11. SID 6E",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1931,8 +1931,8 @@
         {
           "id": "4073b493-b7e2-4632-8b61-9216a3a07088",
           "name": "LFBE 09",
-          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09. TAKEOFF 09. @SID @8E",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09. TAKEOFF 09. SID 8E",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1940,8 +1940,8 @@
         {
           "id": "97e54279-5645-4efa-bbb0-788e7957bb49",
           "name": "LFBE 27",
-          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27. TAKEOFF 27. @SID @8W",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27. TAKEOFF 27. SID 8W",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2313,8 +2313,8 @@
         {
           "id": "c8c2265e-835e-4de3-b8e1-a32a053b1ffa",
           "name": "LFBH 09",
-          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. @SID @6E",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 6E",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2322,8 +2322,8 @@
         {
           "id": "8819d90d-9773-4b9e-9266-93dce0472fbc",
           "name": "LFBH 27",
-          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. @SID @6W",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. SID 6W",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2695,8 +2695,8 @@
         {
           "id": "0e88d79d-c273-4dce-b698-f2dba55338d9",
           "name": "LFBI 03",
-          "airportConditions": "EXPECT RNP RWY 03. ARR RWY 03, DEP RWY 03. @SID @6T",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 03. ARR RWY 03, DEP RWY 03. SID 6T",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2704,8 +2704,8 @@
         {
           "id": "5f68c2ce-8cc5-4f61-a153-8ec6fe142ae2",
           "name": "LFBI 21",
-          "airportConditions": "EXPECT ILS RWY 21. ARR RWY 21, DEP RWY 21. @SID @6V",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 21. ARR RWY 21, DEP RWY 21. SID 6V",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3078,8 +3078,8 @@
         {
           "id": "8799203a-4d6a-4cd6-b396-b737dfb76495",
           "name": "LFBL 03",
-          "airportConditions": "EXPECT RNP RWY 03. ARR RWY 03, DEP RWY 03. @SID @3A",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 03. ARR RWY 03, DEP RWY 03. SID 3A",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3087,8 +3087,8 @@
         {
           "id": "57708391-f267-46a3-84ac-fcd0bbdb0043",
           "name": "LFBL 21",
-          "airportConditions": "EXPECT ILS RWY 21. ARR RWY 21, DEP RWY 21. @SID @3B",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 21. ARR RWY 21, DEP RWY 21. SID 3B",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3461,8 +3461,8 @@
         {
           "id": "878c56ab-b791-4cea-b430-ee479d73f2a4",
           "name": "LFMK 09",
-          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. @SID @3E",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 3E",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3470,8 +3470,8 @@
         {
           "id": "a4f8f17e-f09b-4c3e-a413-51aa6422efa3",
           "name": "LFMK 27",
-          "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. @SID @3W",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. SID 3W",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3844,8 +3844,8 @@
         {
           "id": "3ec729c9-5e1f-4b0a-9020-db509a4c1e41",
           "name": "LFBZ 09",
-          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. @SID @3D AND @3E",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 3D AND 3E",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3853,8 +3853,8 @@
         {
           "id": "cbbdbcfa-31a6-45e6-ac59-91081782596c",
           "name": "LFBZ 27",
-          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. @SID @3F AND @3W",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. SID 3F AND 3W",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }

--- a/vATIS Profile - LFEE.json
+++ b/vATIS Profile - LFEE.json
@@ -345,8 +345,8 @@
         {
           "id": "8f242676-50d8-432e-9300-4a9251f9f601",
           "name": "LFSB 15",
-          "airportConditions": "EXPECT ILS @Z RWY 15. ARR RWY 15, DEP RWY 15. @SID @7S AND @7T",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS Z RWY 15. ARR RWY 15, DEP RWY 15. SID 7S AND 7T",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -354,8 +354,8 @@
         {
           "id": "3a3e23d5-5f88-4291-abd1-082a44e10f95",
           "name": "LFSB 33",
-          "airportConditions": "EXPECT ILS @Z RWY 33. ARR RWY 33, DEP RWY 33. @SID @7N",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS Z RWY 33. ARR RWY 33, DEP RWY 33. SID 7N",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -738,8 +738,8 @@
         {
           "id": "5df34dcf-85ab-49d5-989f-48211f9a8368",
           "name": "LFST 05",
-          "airportConditions": "EXPECT ILS RWY 05. ARR RWY 05, DEP RWY 05. @SID @8M",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 05. ARR RWY 05, DEP RWY 05. SID 8M",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -747,8 +747,8 @@
         {
           "id": "4540ab11-4701-4e81-a062-2b012316f3e6",
           "name": "LFST 23",
-          "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. @SID @8H",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. SID 8H",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1121,8 +1121,8 @@
         {
           "id": "0ac85dc2-b0b3-4d97-860f-0820520281ba",
           "name": "LFJL 04",
-          "airportConditions": "EXPECT RNP RWY 04. ARR RWY 04, DEP RWY 04. @SID @5N",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 04. ARR RWY 04, DEP RWY 04. SID 5N",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1130,8 +1130,8 @@
         {
           "id": "3942923b-1498-425f-a2d8-73144b9c00e8",
           "name": "LFJL 22",
-          "airportConditions": "EXPECT ILS RWY 22. ARR RWY 22, DEP RWY 22. @SID @6S",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 22. ARR RWY 22, DEP RWY 22. SID 6S",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }

--- a/vATIS Profile - LFFF.json
+++ b/vATIS Profile - LFFF.json
@@ -345,8 +345,8 @@
         {
           "id": "24f418d4-5ecd-499d-8817-49be2b84c216",
           "name": "LFPG 08/09 EL",
-          "airportConditions": "EXPECT @7E @7N ILS ^09L AND @7E @7N ILS ^08R. ARR RWYS 09L AND ^08R, DEP RWYS 09R AND ^08L. @SID @6G AND @6H.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7E 7N ILS ^09L AND 7E 7N ILS ^08R. ARR RWYS 09L AND ^08R, DEP RWYS 09R AND ^08L. SID 6G AND 6H.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -354,8 +354,8 @@
         {
           "id": "46433c45-4f02-4d74-bcbd-8e9219de1f1d",
           "name": "LFPG 26/27 WL",
-          "airportConditions": "EXPECT @7W ILS ^27R AND @7W ILS ^26L. ARR RWYS 27R AND ^26L, DEP RWYS 27L AND ^26R. @SID @6A AND @6B.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7W ILS ^27R AND 7W ILS ^26L. ARR RWYS 27R AND ^26L, DEP RWYS 27L AND ^26R. SID 6A AND 6B.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -363,8 +363,8 @@
         {
           "id": "41817aa5-6464-4449-954f-f50002405587",
           "name": "LFPG 08/09 EI",
-          "airportConditions": "EXPECT @7E @7N ILS ^09L AND @7E @7N ILS ^08R. ARR RWYS 09L AND ^08R, DEP RWYS 09R AND ^08L. @SID @6K AND @6L.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7E 7N ILS ^09L AND 7E 7N ILS ^08R. ARR RWYS 09L AND ^08R, DEP RWYS 09R AND ^08L. SID 6K AND 6L.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -372,8 +372,8 @@
         {
           "id": "892c3007-e9fd-4887-92cb-e99d1351b357",
           "name": "LFPG 26/27 WI",
-          "airportConditions": "EXPECT @7W ILS ^27R AND @7W ILS ^26L. ARR RWYS 27R AND ^26L, DEP RWYS 27L AND ^26R. @SID @6D AND @6E.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7W ILS ^27R AND 7W ILS ^26L. ARR RWYS 27R AND ^26L, DEP RWYS 27L AND ^26R. SID 6D AND 6E.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -469,7 +469,7 @@
           "enabled": false
         },
         {
-          "text": "SEND YOUR @TOBT AT @CDMURL.",
+          "text": "SEND YOUR TOBT AT CDMURL.",
           "ordinal": 2,
           "enabled": false
         }
@@ -817,9 +817,9 @@
         {
           "id": "0c6fa667-b19a-4def-a167-6d5a330ca8f8",
           "name": "LFPO 24/25 WL",
-          "airportConditions": "EXPECT @7W ILS 25. ARR RWY 25, DEP RWY 24. @SID @2W.",
+          "airportConditions": "EXPECT 7W ILS 25. ARR RWY 25, DEP RWY 24. SID 2W.",
           "notams": "",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -827,9 +827,9 @@
         {
           "id": "59d33953-ceb1-4678-84f1-03a2a13a1bd9",
           "name": "LFPO 07/06 EL",
-          "airportConditions": "EXPECT @7E ILS 06. ARR RWY 06, DEP RWY 07. @SID @2E.",
+          "airportConditions": "EXPECT 7E ILS 06. ARR RWY 06, DEP RWY 07. SID 2E.",
           "notams": "",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -837,8 +837,8 @@
         {
           "id": "bdb0ab47-6fa0-4803-b984-856bd66397e9",
           "name": "LFPO 24/25 WI",
-          "airportConditions": "EXPECT @7W ILS 25. ARR RWY 25, DEP RWY 24. @SID @2Q.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7W ILS 25. ARR RWY 25, DEP RWY 24. SID 2Q.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -846,8 +846,8 @@
         {
           "id": "7be05da3-3954-4f08-825c-80964fd0d9ba",
           "name": "LFPO 07/06 EI",
-          "airportConditions": "EXPECT @7E @7Y ILS 06. ARR RWY 06, DEP RWY 07. @SID @2G.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7E 7Y ILS 06. ARR RWY 06, DEP RWY 07. SID 2G.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -918,7 +918,7 @@
           "enabled": false
         },
         {
-          "text": "SEND YOUR @TOBT AT @CDMURL.",
+          "text": "SEND YOUR TOBT AT CDMURL.",
           "ordinal": 2,
           "enabled": false
         }
@@ -1266,8 +1266,8 @@
         {
           "id": "985d0721-8049-4540-a5a7-2d8ca76009f8",
           "name": "LFPB 07/09 EL",
-          "airportConditions": "EXPECT @7E ILS 07. ARR RWY 07, DEP RWY 09. @SID @6J.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7E ILS 07. ARR RWY 07, DEP RWY 09. SID 6J.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1275,8 +1275,8 @@
         {
           "id": "cad0e3e9-105e-4f52-884a-ec99f021fe91",
           "name": "LFPB 27/25 WL",
-          "airportConditions": "EXPECT @7W ILS 27. ARR RWY 27, DEP RWY 25. @SID @6C.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7W ILS 27. ARR RWY 27, DEP RWY 25. SID 6C.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1284,8 +1284,8 @@
         {
           "id": "e6d04e42-c3fd-4219-a9a6-8d0983a47cf6",
           "name": "LFPB 07/09 EI",
-          "airportConditions": "EXPECT @7E ILS 07. ARR RWY 07, DEP RWY 09. @SID @6M.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7E ILS 07. ARR RWY 07, DEP RWY 09. SID 6M.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1293,8 +1293,8 @@
         {
           "id": "eee14f80-7138-4501-9e5e-f157108fa746",
           "name": "LFPB 27/25 WI",
-          "airportConditions": "EXPECT @7W ILS 27. ARR RWY 27, DEP RWY 25. @SID @6F.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT 7W ILS 27. ARR RWY 27, DEP RWY 25. SID 6F.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1687,8 +1687,8 @@
         {
           "id": "1261750c-9c86-4a1f-8f7d-c55e16ec1327",
           "name": "LFOB 12 (PG EAST)",
-          "airportConditions": "EXPECT ILS RWY 12. ARR RWY 12, DEP RWY 12. @SID @1S @1M.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 12. ARR RWY 12, DEP RWY 12. SID 1S 1M.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1696,8 +1696,8 @@
         {
           "id": "6379bad0-8a4a-4c19-aae7-813d5278557f",
           "name": "LFOB 30 (PG WEST)",
-          "airportConditions": "EXPECT ILS RWY 30. ARR RWY 30, DEP RWY 30. @SID @1W @1N.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 30. ARR RWY 30, DEP RWY 30. SID 1W 1N.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1705,8 +1705,8 @@
         {
           "id": "2b48df35-e668-4b87-9e89-b379a616e2a3",
           "name": "LFOB 12 (PG WEST)",
-          "airportConditions": "EXPECT ILS RWY 12. ARR RWY 12, DEP RWY 12. @SID @1V @1M.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 12. ARR RWY 12, DEP RWY 12. SID 1V 1M.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1714,8 +1714,8 @@
         {
           "id": "fb1793c6-8261-4a3e-ac27-49828d7e7b13",
           "name": "LFOB 30 (PG EAST)",
-          "airportConditions": "EXPECT ILS RWY 30. ARR RWY 30, DEP RWY 30. @SID @1T @1N.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 30. ARR RWY 30, DEP RWY 30. SID 1T 1N.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2108,8 +2108,8 @@
         {
           "id": "edaea05f-37ce-41c9-b69d-ea43fca7b3b9",
           "name": "LFQQ 08",
-          "airportConditions": "EXPECT RNP RWY 08. ARR RWY 08, DEP RWY 08. @SID @6R.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 08. ARR RWY 08, DEP RWY 08. SID 6R.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2117,8 +2117,8 @@
         {
           "id": "506e2711-325d-4564-9439-92512dfabe01",
           "name": "LFQQ 26",
-          "airportConditions": "EXPECT ILS RWY 26. ARR RWY 26, DEP RWY 26. @SID @6K AND @6L.",
-          "template": "@BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 26. ARR RWY 26, DEP RWY 26. SID 6K AND 6L.",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }

--- a/vATIS Profile - LFRR.json
+++ b/vATIS Profile - LFRR.json
@@ -345,8 +345,8 @@
         {
           "id": "a2928c8b-1468-4b3c-814a-0f12f25f6d1a",
           "name": "LFRS 03",
-          "airportConditions": "EXPECT ILS RWY 03. ARR RWY 03, DEP RWY 03. @SID @4N",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 03. ARR RWY 03, DEP RWY 03. SID 4N",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -354,8 +354,8 @@
         {
           "id": "5dc442fa-1c3a-453a-90c8-92d8ff2d71dd",
           "name": "LFRS 21",
-          "airportConditions": "EXPECT RNP RWY 21. ARR RWY 21, DEP RWY 21. @SID @4S",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP RWY 21. ARR RWY 21, DEP RWY 21. SID 4S",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -728,8 +728,8 @@
         {
           "id": "e7a9e558-e498-44b4-a9d8-4568c642bc08",
           "name": "LFRB 25",
-          "airportConditions": "EXPECT ILS RWY 25L. ARR RWY 25L, DEP RWY 25L. @SID @6W",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND]. [TL]. [FULL_WX_STRING]. CONFIRM ON INITIAL CONTACT THAT YOU HAVE RECEIVED INFORMATION [ATIS_CODE]",
+          "airportConditions": "EXPECT ILS RWY 25L. ARR RWY 25L, DEP RWY 25L. SID 6W",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND]. [TL]. [FULL_WX_STRING]. CONFIRM ON INITIAL CONTACT THAT YOU HAVE RECEIVED INFORMATION [ATIS_CODE]",
           "externalGenerator": {
             "enabled": false
           }
@@ -737,8 +737,8 @@
         {
           "id": "bb037a81-e627-410e-9dfc-0ca96b680210",
           "name": "LFRB 07",
-          "airportConditions": "EXPECT RNP RWY 07R. ARR RWY 07R, DEP RWY 07R. @SID @6F",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND]. [TL]. [FULL_WX_STRING]. CONFIRM ON INITIAL CONTACT THAT YOU HAVE RECEIVED INFORMATION [ATIS_CODE]",
+          "airportConditions": "EXPECT RNP RWY 07R. ARR RWY 07R, DEP RWY 07R. SID 6F",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND]. [TL]. [FULL_WX_STRING]. CONFIRM ON INITIAL CONTACT THAT YOU HAVE RECEIVED INFORMATION [ATIS_CODE]",
           "externalGenerator": {
             "enabled": false
           }
@@ -1111,8 +1111,8 @@
         {
           "id": "fa7aa900-2279-4c53-97f7-3731ea16b118",
           "name": "LFRN 10",
-          "airportConditions": "EXPECT ILS RWY 10. ARR RWY 10, DEP RWY 10. @SID @5T",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 10. ARR RWY 10, DEP RWY 10. SID 5T",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1120,8 +1120,8 @@
         {
           "id": "c6bc8603-eb1f-4a76-b4d4-e05b3ad65268",
           "name": "LFRN 28",
-          "airportConditions": "EXPECT ILS RWY 28. ARR RWY 28, DEP RWY 28. @SID @5V AND @5W",
-          "template": "@BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT ILS RWY 28. ARR RWY 28, DEP RWY 28. SID 5V AND 5W",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }


### PR DESCRIPTION
The `@` before a contraction is no longer required since [v4.1.0-beta.8](https://github.com/vatis-project/vatis/releases/tag/v4.1.0-beta.8).