### PR TITLE
LFMD SID designator and fix for missing space

### DIFF
--- a/vATIS Profile - LFBB.json
+++ b/vATIS Profile - LFBB.json
@@ -3,7 +3,7 @@
   "name": "LFBB",
   "id": "149be2dc-b691-4950-9921-35027760dfcb",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFBB.json",
-  "updateSerial": 2026022501,
+  "updateSerial": 2026042301,
   "stations": [
     {
       "id": "87b9a4f6-1fa7-42d3-ab0a-07cf38622b3c",

--- a/vATIS Profile - LFBB.json
+++ b/vATIS Profile - LFBB.json
@@ -3,7 +3,7 @@
   "name": "LFBB",
   "id": "149be2dc-b691-4950-9921-35027760dfcb",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFBB.json",
-  "updateSerial": 2026041201,
+  "updateSerial": 2026022501,
   "stations": [
     {
       "id": "87b9a4f6-1fa7-42d3-ab0a-07cf38622b3c",
@@ -348,7 +348,7 @@
           "id": "08674f88-f17f-450b-9d81-a884e711bc7b",
           "name": "LFBO 32",
           "airportConditions": "EXPECT ILS RWY 32L. ARR RWY 32L, DEP RWY 32R. SID 7B",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -357,7 +357,7 @@
           "id": "3562cbdd-d40e-4b82-b942-c757ba2f3855",
           "name": "LFBO 14",
           "airportConditions": "EXPECT ILS RWY 14R. ARR RWY 14R, DEP RWY 14L. SID 7A",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -747,7 +747,7 @@
           "id": "cd6daa1b-1ce0-403b-a64a-c0713c657584",
           "name": "LFBP 31",
           "airportConditions": "EXPECT ILS RWY 31. ARR RWY 31, DEP RWY 31. SID 2V",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -756,7 +756,7 @@
           "id": "e72b93df-25b7-4565-a3a0-72d525c6229e",
           "name": "LFBP 13",
           "airportConditions": "EXPECT VOR THEN VPT A RWY 13. ARR RWY 13, DEP RWY 13. SID 2D",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1135,7 +1135,7 @@
           "id": "b047ad12-0ea7-4885-ab84-e2ff76dc3f50",
           "name": "LFBT 02",
           "airportConditions": "EXPECT ILS Z THEN VPT RWY 02. ARR RWY 02, DEP RWY 02. SID 2M",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1144,7 +1144,7 @@
           "id": "5ea0e31f-f735-402a-a4b9-999ba4df1822",
           "name": "LFBT 20",
           "airportConditions": "EXPECT ILS RWY 20. ARR RWY 20, DEP RWY 20. SID 2R",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1523,7 +1523,7 @@
           "id": "65a6fa81-e78f-4d83-ba19-4b84b87b5643",
           "name": "LFBD 23",
           "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. SID 6P",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1532,7 +1532,7 @@
           "id": "01af66f9-d860-421d-bbbd-bd1730a0e33c",
           "name": "LFBD 05",
           "airportConditions": "EXPECT RNP RWY 05. ARR RWY 05, DEP RWY 05. SID 6Q",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1541,7 +1541,7 @@
           "id": "00260a51-2930-4dac-b15f-52c2861516cf",
           "name": "LFBD 29",
           "airportConditions": "EXPECT ILS RWY 29. ARR RWY 29, DEP RWY 29. SID 6R",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1550,7 +1550,7 @@
           "id": "23d444e1-b06a-4b10-b61a-567522158990",
           "name": "LFBD 11",
           "airportConditions": "EXPECT RNP RWY 11. ARR RWY 11, DEP RWY 11. SID 6E",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1934,7 +1934,7 @@
           "id": "4073b493-b7e2-4632-8b61-9216a3a07088",
           "name": "LFBE 09",
           "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09. TAKEOFF 09. SID 8E",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1943,7 +1943,7 @@
           "id": "97e54279-5645-4efa-bbb0-788e7957bb49",
           "name": "LFBE 27",
           "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27. TAKEOFF 27. SID 8W",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2316,7 +2316,7 @@
           "id": "c8c2265e-835e-4de3-b8e1-a32a053b1ffa",
           "name": "LFBH 09",
           "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 6E",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2325,7 +2325,7 @@
           "id": "8819d90d-9773-4b9e-9266-93dce0472fbc",
           "name": "LFBH 27",
           "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. SID 6W",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2698,7 +2698,7 @@
           "id": "0e88d79d-c273-4dce-b698-f2dba55338d9",
           "name": "LFBI 03",
           "airportConditions": "EXPECT RNP RWY 03. ARR RWY 03, DEP RWY 03. SID 6T",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2707,7 +2707,7 @@
           "id": "5f68c2ce-8cc5-4f61-a153-8ec6fe142ae2",
           "name": "LFBI 21",
           "airportConditions": "EXPECT ILS RWY 21. ARR RWY 21, DEP RWY 21. SID 6V",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3081,7 +3081,7 @@
           "id": "8799203a-4d6a-4cd6-b396-b737dfb76495",
           "name": "LFBL 03",
           "airportConditions": "EXPECT RNP RWY 03. ARR RWY 03, DEP RWY 03. SID 4A",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3090,7 +3090,7 @@
           "id": "57708391-f267-46a3-84ac-fcd0bbdb0043",
           "name": "LFBL 21",
           "airportConditions": "EXPECT ILS RWY 21. ARR RWY 21, DEP RWY 21. SID 4B",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3464,7 +3464,7 @@
           "id": "878c56ab-b791-4cea-b430-ee479d73f2a4",
           "name": "LFMK 09",
           "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 3E",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3473,7 +3473,7 @@
           "id": "a4f8f17e-f09b-4c3e-a413-51aa6422efa3",
           "name": "LFMK 27",
           "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. SID 3W",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3847,7 +3847,7 @@
           "id": "3ec729c9-5e1f-4b0a-9020-db509a4c1e41",
           "name": "LFBZ 09",
           "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 3D AND 3E",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3856,7 +3856,7 @@
           "id": "cbbdbcfa-31a6-45e6-ac59-91081782596c",
           "name": "LFBZ 27",
           "airportConditions": "EXPECT ILS RWY 27. ARR RWY 27, DEP RWY 27. SID 3F AND 3W",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }

--- a/vATIS Profile - LFEE.json
+++ b/vATIS Profile - LFEE.json
@@ -3,7 +3,7 @@
   "name": "LFEE",
   "id": "cfd59cef-db10-41e7-b8ec-00d4f809f0cf",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFEE.json",
-  "updateSerial": 2026022501,
+  "updateSerial": 2026042301,
   "stations": [
     {
       "id": "f5f01323-dd5e-499c-a46a-02b2da877db0",

--- a/vATIS Profile - LFEE.json
+++ b/vATIS Profile - LFEE.json
@@ -3,7 +3,7 @@
   "name": "LFEE",
   "id": "cfd59cef-db10-41e7-b8ec-00d4f809f0cf",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFEE.json",
-  "updateSerial": 2026041201,
+  "updateSerial": 2026022501,
   "stations": [
     {
       "id": "f5f01323-dd5e-499c-a46a-02b2da877db0",
@@ -348,7 +348,7 @@
           "id": "8f242676-50d8-432e-9300-4a9251f9f601",
           "name": "LFSB 15",
           "airportConditions": "EXPECT ILS Z RWY 15. ARR RWY 15, DEP RWY 15. SID 8S AND 8T",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -357,7 +357,7 @@
           "id": "3a3e23d5-5f88-4291-abd1-082a44e10f95",
           "name": "LFSB 33",
           "airportConditions": "EXPECT ILS Z RWY 33. ARR RWY 33, DEP RWY 33. SID 8N",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -741,7 +741,7 @@
           "id": "5df34dcf-85ab-49d5-989f-48211f9a8368",
           "name": "LFST 05",
           "airportConditions": "EXPECT ILS RWY 05. ARR RWY 05, DEP RWY 05. SID 8M",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -750,7 +750,7 @@
           "id": "4540ab11-4701-4e81-a062-2b012316f3e6",
           "name": "LFST 23",
           "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. SID 8H",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1124,7 +1124,7 @@
           "id": "0ac85dc2-b0b3-4d97-860f-0820520281ba",
           "name": "LFJL 04",
           "airportConditions": "EXPECT RNP RWY 04. ARR RWY 04, DEP RWY 04. SID 5N",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1133,7 +1133,7 @@
           "id": "3942923b-1498-425f-a2d8-73144b9c00e8",
           "name": "LFJL 22",
           "airportConditions": "EXPECT ILS RWY 22. ARR RWY 22, DEP RWY 22. SID 6S",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }

--- a/vATIS Profile - LFFF.json
+++ b/vATIS Profile - LFFF.json
@@ -3,7 +3,7 @@
   "name": "LFFF",
   "id": "5b2ef6b9-21e9-4774-a8fc-27111ec75969",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFFF.json",
-  "updateSerial": 2026022501,
+  "updateSerial": 2026042301,
   "stations": [
     {
       "id": "2832e98f-55a4-4785-b08b-178ac694a948",

--- a/vATIS Profile - LFFF.json
+++ b/vATIS Profile - LFFF.json
@@ -3,7 +3,7 @@
   "name": "LFFF",
   "id": "5b2ef6b9-21e9-4774-a8fc-27111ec75969",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFFF.json",
-  "updateSerial": 2026041201,
+  "updateSerial": 2026022501,
   "stations": [
     {
       "id": "2832e98f-55a4-4785-b08b-178ac694a948",
@@ -348,7 +348,7 @@
           "id": "24f418d4-5ecd-499d-8817-49be2b84c216",
           "name": "LFPG 08/09 EL",
           "airportConditions": "EXPECT 1E 1N ILS ^09L AND 1E 1N ILS ^08R. ARR RWYS ^09L AND ^08R, DEP RWYS ^09R AND ^08L. SID 6G AND 6H.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -357,7 +357,7 @@
           "id": "46433c45-4f02-4d74-bcbd-8e9219de1f1d",
           "name": "LFPG 26/27 WL",
           "airportConditions": "EXPECT 1W ILS ^27R AND 1W ILS ^26L. ARR RWYS ^27R AND ^26L, DEP RWYS ^27L AND ^26R. SID 6A AND 6B.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -366,7 +366,7 @@
           "id": "41817aa5-6464-4449-954f-f50002405587",
           "name": "LFPG 08/09 EI",
           "airportConditions": "EXPECT 1E 1N ILS ^09L AND 1E 7N ILS ^08R. ARR RWYS ^09L AND ^08R, DEP RWYS ^09R AND ^08L. SID 6K AND 6L.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -375,7 +375,7 @@
           "id": "892c3007-e9fd-4887-92cb-e99d1351b357",
           "name": "LFPG 26/27 WI",
           "airportConditions": "EXPECT 1W ILS ^27R AND 1W ILS ^26L. ARR RWYS ^27R AND ^26L, DEP RWYS ^27L AND ^26R. SID 6D AND 6E.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -821,7 +821,7 @@
           "name": "LFPO 24/25 WL",
           "airportConditions": "EXPECT 1W ILS 25. ARR RWY 25, DEP RWY 24. SID 2W.",
           "notams": "",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -831,7 +831,7 @@
           "name": "LFPO 07/06 EL",
           "airportConditions": "EXPECT 1E ILS 06. ARR RWY 06, DEP RWY 07. SID 2E.",
           "notams": "",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -840,7 +840,7 @@
           "id": "bdb0ab47-6fa0-4803-b984-856bd66397e9",
           "name": "LFPO 24/25 WI",
           "airportConditions": "EXPECT 1W ILS 25. ARR RWY 25, DEP RWY 24. SID 2Q.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -849,7 +849,7 @@
           "id": "7be05da3-3954-4f08-825c-80964fd0d9ba",
           "name": "LFPO 07/06 EI",
           "airportConditions": "EXPECT 1E 1Y ILS 06. ARR RWY 06, DEP RWY 07. SID 2G.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1269,7 +1269,7 @@
           "id": "985d0721-8049-4540-a5a7-2d8ca76009f8",
           "name": "LFPB 07/09 EL",
           "airportConditions": "EXPECT 1E ILS 07. ARR RWY 07, DEP RWY 09. SID 6J.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1278,7 +1278,7 @@
           "id": "cad0e3e9-105e-4f52-884a-ec99f021fe91",
           "name": "LFPB 27/25 WL",
           "airportConditions": "EXPECT 1W ILS 27. ARR RWY 27, DEP RWY 25. SID 6C.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1287,7 +1287,7 @@
           "id": "e6d04e42-c3fd-4219-a9a6-8d0983a47cf6",
           "name": "LFPB 07/09 EI",
           "airportConditions": "EXPECT 1E ILS 07. ARR RWY 07, DEP RWY 09. SID 6M.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1296,7 +1296,7 @@
           "id": "eee14f80-7138-4501-9e5e-f157108fa746",
           "name": "LFPB 27/25 WI",
           "airportConditions": "EXPECT 1W ILS 27. ARR RWY 27, DEP RWY 25. SID 6F.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1690,7 +1690,7 @@
           "id": "1261750c-9c86-4a1f-8f7d-c55e16ec1327",
           "name": "LFOB 12 (PG EAST)",
           "airportConditions": "EXPECT ILS RWY 12. ARR RWY 12, DEP RWY 12. SID 1S 1M.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1699,7 +1699,7 @@
           "id": "6379bad0-8a4a-4c19-aae7-813d5278557f",
           "name": "LFOB 30 (PG WEST)",
           "airportConditions": "EXPECT ILS RWY 30. ARR RWY 30, DEP RWY 30. SID 1W 1N.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1708,7 +1708,7 @@
           "id": "2b48df35-e668-4b87-9e89-b379a616e2a3",
           "name": "LFOB 12 (PG WEST)",
           "airportConditions": "EXPECT ILS RWY 12. ARR RWY 12, DEP RWY 12. SID 1V 1M.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1717,7 +1717,7 @@
           "id": "fb1793c6-8261-4a3e-ac27-49828d7e7b13",
           "name": "LFOB 30 (PG EAST)",
           "airportConditions": "EXPECT ILS RWY 30. ARR RWY 30, DEP RWY 30. SID 1T 1N.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2111,7 +2111,7 @@
           "id": "edaea05f-37ce-41c9-b69d-ea43fca7b3b9",
           "name": "LFQQ 08",
           "airportConditions": "EXPECT RNP RWY 08. ARR RWY 08, DEP RWY 08. SID 6R.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2120,7 +2120,7 @@
           "id": "506e2711-325d-4564-9439-92512dfabe01",
           "name": "LFQQ 26",
           "airportConditions": "EXPECT ILS RWY 26. ARR RWY 26, DEP RWY 26. SID 6K AND 6L.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4138,7 +4138,7 @@
           "name": "LFPN 25R WL",
           "airportConditions": "EXPECT APPROACH 1W 1X ILS ^25R. ARR RWY ^25R, DEP RWY ^25R. SID 2P.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4148,7 +4148,7 @@
           "name": "LFPN 07L EL",
           "airportConditions": "EXPECT APPROACH 1E 1F RNP^07L. ARR RWY^07L, DEP RWY^07L. SID 2A.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4158,7 +4158,7 @@
           "name": "LFPN 25R WI",
           "airportConditions": "EXPECT APPROACH 1W 1X ILS ^25R. ARR RWY ^25R, DEP RWY ^25R. SID 2V.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4168,7 +4168,7 @@
           "name": "LFPN 07L EI",
           "airportConditions": "EXPECT APPROACH 1F 1Y RNP^07L. ARR RWY^07L, DEP RWY^07L. SID 2B.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -6216,7 +6216,7 @@
           "name": "LFAT 13",
           "airportConditions": "EXPECT ILS RWY 13. ARR RWY 13, DEP RWY 13. SID 1Y.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false,
             "textUrl": "",
@@ -6232,7 +6232,7 @@
           "name": "LFAT 31",
           "airportConditions": "EXPECT RNP RWY 31. ARR RWY 31, DEP RWY 31. SID 1Z.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }

--- a/vATIS Profile - LFMM.json
+++ b/vATIS Profile - LFMM.json
@@ -3,7 +3,7 @@
   "name": "LFMM",
   "id": "74bf29c6-12b2-41c4-b318-77739a38300d",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFMM.json",
-  "updateSerial": 2026041201,
+  "updateSerial": 2026022501,
   "stations": [
     {
       "id": "4e8ab8ca-65ca-4f68-8c6f-4726c3789062",
@@ -348,7 +348,7 @@
           "id": "d8769532-b9ff-415a-be36-813843d57777",
           "name": "LFMT 12",
           "airportConditions": "EXPECT RNP RWY 12L. ARR RWY 12L, DEP RWY 12L. SID 8L",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -357,7 +357,7 @@
           "id": "1a764042-3e6f-4bc8-873b-e5d614115faf",
           "name": "LFMT 30",
           "airportConditions": "EXPECT ILS Z RWY 30R. ARR RWY 30R, DEP RWY 30R. SID 8R",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -736,7 +736,7 @@
           "id": "dee65e3a-9398-4f3a-8c72-98f4856aa011",
           "name": "LFMP 15",
           "airportConditions": "EXPECT RNP RWY 15. ARR RWY 15, DEP RWY 15. SID 5S AND 5W",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -745,7 +745,7 @@
           "id": "1b6c8a55-345f-4f57-9d5d-45c4f59a92a6",
           "name": "LFMP 33",
           "airportConditions": "EXPECT ILS RWY 33. ARR RWY 33, DEP RWY 33. SID 5N AND 5X",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1129,7 +1129,7 @@
           "id": "d20c9d6b-b62d-429e-be55-058ab2a1a96b",
           "name": "LFLL 35",
           "airportConditions": "EXPECT ILS RWY 35R /ARR RWY 35R /DEP RWY 35L /SID 8N.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1138,7 +1138,7 @@
           "id": "dcbc539e-d45b-4e17-b96b-155ec8fedcf0",
           "name": "LFLL 17",
           "airportConditions": "EXPECT ILS RWY 17L /ARR RWY 17L /DEP RWY 17R /SID 8S.",
-          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] ATIS [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1533,7 +1533,7 @@
           "id": "4bdd46dd-561c-4891-90d2-e0c087c6c65d",
           "name": "LFLB 18",
           "airportConditions": "EXPECT ILS RWY 18. ARR RWY 18, DEP RWY 18. SID 2L",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1542,7 +1542,7 @@
           "id": "ae66fa0c-0f51-4f69-8e05-fbef68ae5a84",
           "name": "LFLB 36",
           "airportConditions": "EXPECT ILS RWY 18 THEN VISUAL RWY 36. ARR RWY 36, DEP RWY 36. SID 2C",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1551,7 +1551,7 @@
           "id": "cfb5a2a5-0c1d-49c3-996c-4840ea185113",
           "name": "LFLB 18/36",
           "airportConditions": "EXPECT ILS RWY 18. ARR RWY 18, DEP RWY 36. SID 2C",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1930,7 +1930,7 @@
           "id": "6446f85b-aeec-43e2-ad68-f30d1fff955b",
           "name": "LFML 31",
           "airportConditions": "EXPECT RNP Z RWY 31R. ARR RWY 31R, DEP RWY 31R. SID 6N",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1939,7 +1939,7 @@
           "id": "2c85ab50-fa92-4b27-91c2-7ec58780a7a8",
           "name": "LFML 13",
           "airportConditions": "EXPECT ILS Z RWY 13L. ARR RWY 13L, DEP RWY 13L. SID 6S",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1948,7 +1948,7 @@
           "id": "83602623-25db-4f0a-a059-ffc1434af15a",
           "name": "LFML 13/31 NIGHT",
           "airportConditions": "EXPECT ILS Z RWY 13L. ARR RWY 13L, DEP RWY 31R. SID 6N",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2326,8 +2326,8 @@
         {
           "id": "3a33ef81-5f7c-46c0-b6f6-96b349c73639",
           "name": "LFMN 04 RNP A",
-          "airportConditions": "EXPECT RNP A THEN VPT A RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 8A, 8B",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP A THEN VPT A RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 7A, 7B",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2335,8 +2335,8 @@
         {
           "id": "6994627e-6062-4245-a6bf-a68a6a1c75c1",
           "name": "LFMN 04 RNP Z",
-          "airportConditions": "EXPECT RNP Z RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 8A, 8B",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP Z RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 7A, 7B",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2344,8 +2344,8 @@
         {
           "id": "705b5fed-af17-4d46-ad43-419676337b91",
           "name": "LFMN 22",
-          "airportConditions": "EXPECT RNP D THEN VPT D RWY 22R. RNP Z ON RQST /ARR RWY 22R /DEP RWY 22L /SID 8X, 8Y",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP D THEN VPT D RWY 22R. RNP Z ON RQST /ARR RWY 22R /DEP RWY 22L /SID 7X, 7Y",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2774,8 +2774,8 @@
         {
           "id": "b2696a77-27bd-4171-99b5-c3b4eebd628a",
           "name": "LFMD 17 LOC A",
-          "airportConditions": "EXPECT LOC A RWY 17 THEN VPT A RWY 17. ARR RWY 17, DEP RWY 17. SID 1K.",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT LOC A RWY 17 THEN VPT A RWY 17. ARR RWY 17, DEP RWY 17. SID 1N, 1K.",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2783,8 +2783,8 @@
         {
           "id": "fd98c929-96bd-467f-b362-2a4491d4a455",
           "name": "LFMD 17 RNP A",
-          "airportConditions": "EXPECT RNP A RWY 17 THEN VPT A RWY 17. ARR RWY 17, DEP RWY 17. SID 1K.",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP A RWY 17 THEN VPT A RWY 17. ARR RWY 17, DEP RWY 17. SID 1N, 1K.",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2792,8 +2792,8 @@
         {
           "id": "f6cec980-87d4-4195-8e4f-b5262d8768e0",
           "name": "LFMD 35",
-          "airportConditions": "EXPECT RNP Y RWY 35. ARR RWY 35, DEP RWY 17. SID 1K.",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "airportConditions": "EXPECT RNP Y RWY 35. ARR RWY 35, DEP RWY 17. SID 1N, 1K.",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -2811,9 +2811,14 @@
           "voice": "DEPARTURES"
         },
         {
-          "variableName": "9K",
-          "text": "9K",
-          "voice": "NINE KILO"
+          "variableName": "1N",
+          "text": "1N",
+          "voice": "ONE NOVEMBER"
+        },
+        {
+          "variableName": "1K",
+          "text": "1K",
+          "voice": "ONE KILO"
         },
         {
           "variableName": "A",
@@ -3172,7 +3177,7 @@
           "id": "adb337bb-480d-434d-834d-11ad5b5a0eb9",
           "name": "LFKJ 20 PARATA",
           "airportConditions": "CONFIG PARATA. EXPECT VPT A RWY 20. ARR RWY 20, DEP RWY 20. SID 1K.",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3181,7 +3186,7 @@
           "id": "4410f6a7-9d33-4621-8864-e768a1ef2423",
           "name": "LFKJ 02/20 HORRO",
           "airportConditions": "CONFIG HORRO. EXPECT ILS RWY 02. ARR RWY 02, DEP RWY 20. SID 1R.",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3560,7 +3565,7 @@
           "id": "988f0800-0ecb-4f4b-b763-bd58e3b791a3",
           "name": "LFKB 16",
           "airportConditions": "EXPECT RNP RWY 16. LANDING RWY 16, DEP RWY 16. SID 2V",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3569,7 +3574,7 @@
           "id": "575005ef-39a7-455b-bc69-9f3b4ae10b42",
           "name": "LFKB 34",
           "airportConditions": "EXPECT ILS RWY 34. LANDING RWY 34, DEP RWY 34. SID 2R",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3943,7 +3948,7 @@
           "id": "4f6efbba-35fe-4261-ba55-e0f388248f49",
           "name": "LFKC 36",
           "airportConditions": "EXPECT LOC RWY 18 THEN VISUAL RWY 36. ARR RWY 36, DEP RWY 36. SID 1R",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3952,7 +3957,7 @@
           "id": "0e6cccff-7103-4a05-b20c-695b7db41b45",
           "name": "LFKC 36/18",
           "airportConditions": "EXPECT LOC RWY 18. ARR RWY 18, DEP RWY 36. SID 1R",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4321,7 +4326,7 @@
           "id": "197a587e-c704-43b5-89b6-3a8e84557028",
           "name": "LFKF 05",
           "airportConditions": "EXPECT RNP RWY 05. ARR RWY 05, DEP RWY 05. SID 3G",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4330,7 +4335,7 @@
           "id": "e9f97c96-3f79-466c-bb6b-5dcaec9a4675",
           "name": "LFKF 23",
           "airportConditions": "EXPECT ILS RWY 23. ARR RWY 23, DEP RWY 23. SID 4A AND 4M",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4709,7 +4714,7 @@
           "id": "f990c80d-005a-4e21-bddf-390cadc50a1e",
           "name": "LFMU 09",
           "airportConditions": "EXPECT RNP RWY 09. ARR RWY 09, DEP RWY 09. SID 7L",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -4718,7 +4723,7 @@
           "id": "98d80be3-68cf-4a55-ad8c-dacb486be88d",
           "name": "LFMU 27",
           "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. SID 7R",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5092,7 +5097,7 @@
           "id": "4d0a9b89-a4d9-49a6-9ab2-b066edff5eee",
           "name": "LFLC 08",
           "airportConditions": "EXPECT ILS RWY 26 CIRCLING RWY 08. ARR RWY 08, DEP RWY 08. SID 4E",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5101,7 +5106,7 @@
           "id": "121b35c8-3c35-432e-875f-7e31d77b2fc4",
           "name": "LFLC 26/08",
           "airportConditions": "EXPECT ILS RWY 26. ARR RWY 26, DEP RWY 08. SID 4E",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5110,7 +5115,7 @@
           "id": "50c49d0c-99a2-4114-a879-b6b401efba28",
           "name": "LFLC 26",
           "airportConditions": "EXPECT ILS RWY 26. ARR RWY 26, DEP RWY 26. SID 4W",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5484,7 +5489,7 @@
           "id": "01b6c9d3-217a-42fb-901a-daa8b22955eb",
           "name": "LFLS 09",
           "airportConditions": "EXPECT ILS RWY 09. ARR RWY 09, DEP RWY 09. SID 8E",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5493,7 +5498,7 @@
           "id": "33abe9bd-ece5-4a63-819f-02f3d823e7a4",
           "name": "LFLS 27",
           "airportConditions": "EXPECT RNP RWY 27. ARR RWY 27, DEP RWY 27. SID 8W",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5867,7 +5872,7 @@
           "id": "02e47d8a-61a0-4a88-893e-95c0bace04bd",
           "name": "LFTW 18",
           "airportConditions": "EXPECT RNP RWY 18. ARR RWY 18, DEP RWY 18. SID 4S",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5876,7 +5881,7 @@
           "id": "06c471dd-75f1-4502-9270-c2a0766109f3",
           "name": "LFTW 36",
           "airportConditions": "EXPECT RNP RWY 36. ARR RWY 36, DEP RWY 36. SID 4N",
-          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -7888,7 +7893,7 @@
           "name": "LFLY 34",
           "airportConditions": "EXPECT RNP RWY 34. ARR RWY 34, DEP RWY 34. SID 6P.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -7898,7 +7903,7 @@
           "name": "LFLY 16",
           "airportConditions": "EXPECT RNP RWY 16. ARR RWY 16, DEP RWY 16. SID 6T.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false,
             "textUrl": "",

--- a/vATIS Profile - LFMM.json
+++ b/vATIS Profile - LFMM.json
@@ -3199,6 +3199,11 @@
           "voice": "DEPARTURES"
         },
         {
+          "variableName": "1N",
+          "text": "1N",
+          "voice": "ONE NOVEMBER"
+        },
+        {
           "variableName": "1K",
           "text": "1K",
           "voice": "ONE KILO"

--- a/vATIS Profile - LFMM.json
+++ b/vATIS Profile - LFMM.json
@@ -3,7 +3,7 @@
   "name": "LFMM",
   "id": "74bf29c6-12b2-41c4-b318-77739a38300d",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFMM.json",
-  "updateSerial": 2026022501,
+  "updateSerial": 2026042301,
   "stations": [
     {
       "id": "4e8ab8ca-65ca-4f68-8c6f-4726c3789062",
@@ -2326,7 +2326,7 @@
         {
           "id": "3a33ef81-5f7c-46c0-b6f6-96b349c73639",
           "name": "LFMN 04 RNP A",
-          "airportConditions": "EXPECT RNP A THEN VPT A RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 7A, 7B",
+          "airportConditions": "EXPECT RNP A THEN VPT A RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 8A, 8B",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -2335,7 +2335,7 @@
         {
           "id": "6994627e-6062-4245-a6bf-a68a6a1c75c1",
           "name": "LFMN 04 RNP Z",
-          "airportConditions": "EXPECT RNP Z RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 7A, 7B",
+          "airportConditions": "EXPECT RNP Z RWY 04L /ARR RWY 04L /DEP RWY 04R /SID 8A, 8B",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -2344,7 +2344,7 @@
         {
           "id": "705b5fed-af17-4d46-ad43-419676337b91",
           "name": "LFMN 22",
-          "airportConditions": "EXPECT RNP D THEN VPT D RWY 22R. RNP Z ON RQST /ARR RWY 22R /DEP RWY 22L /SID 7X, 7Y",
+          "airportConditions": "EXPECT RNP D THEN VPT D RWY 22R. RNP Z ON RQST /ARR RWY 22R /DEP RWY 22L /SID 8X, 8Y",
           "template": "BONJOUR. [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
@@ -2811,14 +2811,9 @@
           "voice": "DEPARTURES"
         },
         {
-          "variableName": "1N",
-          "text": "1N",
-          "voice": "ONE NOVEMBER"
-        },
-        {
-          "variableName": "1K",
-          "text": "1K",
-          "voice": "ONE KILO"
+          "variableName": "9K",
+          "text": "9K",
+          "voice": "NINE KILO"
         },
         {
           "variableName": "A",

--- a/vATIS Profile - LFRR.json
+++ b/vATIS Profile - LFRR.json
@@ -3,7 +3,7 @@
   "name": "LFRR",
   "id": "4166f265-37cd-4b02-b9c2-cc3b6e4a6618",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFRR.json",
-  "updateSerial": 2026022501,
+  "updateSerial": 2026042301,
   "stations": [
     {
       "id": "25a62aca-ef8e-4dd2-b038-89abc76f130c",

--- a/vATIS Profile - LFRR.json
+++ b/vATIS Profile - LFRR.json
@@ -3,7 +3,7 @@
   "name": "LFRR",
   "id": "4166f265-37cd-4b02-b9c2-cc3b6e4a6618",
   "updateUrl": "https://raw.githubusercontent.com/vaccfr/vatis-profiles/refs/heads/main/vATIS%20Profile%20-%20LFRR.json",
-  "updateSerial": 2026041201,
+  "updateSerial": 2026022501,
   "stations": [
     {
       "id": "25a62aca-ef8e-4dd2-b038-89abc76f130c",
@@ -348,7 +348,7 @@
           "id": "a2928c8b-1468-4b3c-814a-0f12f25f6d1a",
           "name": "LFRS 03",
           "airportConditions": "EXPECT ILS RWY 03. ARR RWY 03, DEP RWY 03. SID 4N",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -357,7 +357,7 @@
           "id": "5dc442fa-1c3a-453a-90c8-92d8ff2d71dd",
           "name": "LFRS 21",
           "airportConditions": "EXPECT RNP RWY 21. ARR RWY 21, DEP RWY 21. SID 4S",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1114,7 +1114,7 @@
           "id": "fa7aa900-2279-4c53-97f7-3731ea16b118",
           "name": "LFRN 10",
           "airportConditions": "EXPECT ILS RWY 10. ARR RWY 10, DEP RWY 10. SID 5T",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -1123,7 +1123,7 @@
           "id": "c6bc8603-eb1f-4a76-b4d4-e05b3ad65268",
           "name": "LFRN 28",
           "airportConditions": "EXPECT ILS RWY 28. ARR RWY 28, DEP RWY 28. SID 5V AND 5W",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS]. [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS]. [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -3141,7 +3141,7 @@
           "name": "LFRG 12",
           "airportConditions": "EXPECT RNP RWY 12. ARR RWY 12, DEP RWY 12. SID 4E AND 1U.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false,
             "textUrl": "",
@@ -3157,7 +3157,7 @@
           "name": "LFRG 30",
           "airportConditions": "EXPECT ILS Z RWY 30. ARR RWY 30, DEP RWY 30. SID 4W AND 1V.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -5180,7 +5180,7 @@
           "name": "LFRD 17",
           "airportConditions": "EXPECT RNP RWY 17. ARR RWY 17, DEP RWY 17. SID 2S.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false,
             "textUrl": "",
@@ -5196,7 +5196,7 @@
           "name": "LFRD 35",
           "airportConditions": "EXPECT RNP RWY 35. ARR RWY 35, DEP RWY 35. SID 2N.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }
@@ -7209,7 +7209,7 @@
           "name": "LFRK 13",
           "airportConditions": "EXPECT RNP RWY 13. ARR RWY 13, DEP RWY 13. SID 4X AND 1S.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false,
             "textUrl": "",
@@ -7225,7 +7225,7 @@
           "name": "LFRK 31",
           "airportConditions": "EXPECT ILS Z RWY 31. ARR RWY 31, DEP RWY 31. SID 4Y AND 1N.",
           "notams": "",
-          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND][NOTAMS] [TL]. [FULL_WX_STRING]. ",
+          "template": "BONJOUR. THIS IS [FACILITY] INFORMATION [ATIS_CODE] RECORDED AT [OBS_TIME]. [ARPT_COND] [NOTAMS] [TL]. [FULL_WX_STRING]. ",
           "externalGenerator": {
             "enabled": false
           }


### PR DESCRIPTION
- Updated LFMD SID designator from 9K to 1N, 1K
- Added missing space between [ARPT_COND] and [NOTAMS] (#36)